### PR TITLE
chore: add psi check

### DIFF
--- a/.github/workflows/psi.yml
+++ b/.github/workflows/psi.yml
@@ -1,0 +1,19 @@
+name: Run Helix PSI Audit
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+    branches:
+      - main
+  pull_request_target:
+    types: [opened, synchronize, reopened, edited]
+jobs:
+  action:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Use repo PSI action
+        uses: auniverseaway/helix-actions-psi@main
+        with:
+          psi-key: ${{ secrets.PSI_KEY }}
+          relative-url: /


### PR DESCRIPTION
Fix #11 

Note: `pull_request_target` should trigger the action for PRs from forks as well