### PR TITLE
fix: use relative target for index

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -7,7 +7,7 @@ indices:
       - '/stories/**'
       - '/people/**'
       - '/toolkit/**'
-    target: https://adobe.sharepoint.com/sites/Adobe.design/Shared%20Documents/website/query-index.xlsx
+    target: /query-index.xlsx
     properties:
       inlineTitle:
         select: main > div > h1:first-child


### PR DESCRIPTION
Makes it more readable, and it avoids making copy+paste errors when creating a new version of the same site.