### PR TITLE
fix: use correct vars for story titles and tag

### DIFF
--- a/blocks/lede/lede.css
+++ b/blocks/lede/lede.css
@@ -127,6 +127,7 @@
 .cmp-lede__title {
   --lede-title-font-size: var(--font-size-900);
   
+  color: var(--reactive-text-color);
   font-size: var(--lede-title-font-size);
   line-height: 1;
   margin-bottom: 2rem;
@@ -135,6 +136,7 @@
 .cmp-lede__sub-title {
   --lede-sub-title-font-size: var(--font-size-400);
   
+  color: var(--reactive-text-color);
   font-family: var(--font-stack-serif);
   font-size: var(--lede-sub-title-font-size);
   font-weight: var(--font-weight-normal);
@@ -145,7 +147,7 @@
 .cmp-lede__tag span {
   --lede-tag-font-size: var(--font-size-100);
 
-  color: var(--color-base-dark-slate-tertiary);
+  color: var(--reactive-text-color);
   display: inline-block;
   font-size: var(--lede-tag-font-size);
   margin-bottom: 2rem;
@@ -155,7 +157,7 @@
 }
 
 .cmp-lede__tag span::after {
-  background-color: var(--color-base-dark-slate-tertiary);
+  background-color: var(--reactive-text-color);
   border-radius: 10px;
   bottom: 0;
   content: '';
@@ -195,7 +197,7 @@ p.cmp-lede__hero-parent {
     --lede-title-font-size: var(--font-size-2500);
 
     grid-column: col-start 2 / span 8;
-    line-height: 0.85;
+    line-height: 0.95;
   }
   
   .cmp-lede__intro {


### PR DESCRIPTION
Fixes an issue where we were using a static color for story title, subtitle and tag.

## Description
URL for testing:

- https://fix--article-heading-colors--design-website--adobe.hlx3.page/

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
