### PR TITLE
feat: sticky positioning on job detail meta info

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -329,6 +329,9 @@ body.job-posts {
 @media (min-width: 900px) {
   .job-posts .cmp-job-post__inner-wrap {
     grid-template-columns: repeat(12, [col-start] 1fr);
+
+    /* align-items needs to be declared so that position: sticky works properly on .cmp-job-post__meta */
+    align-items: start;
   }
 
   .job-posts .cmp-job-post__inner-wrap h1 {
@@ -367,6 +370,8 @@ body.job-posts {
   
   .job-posts .cmp-job-post__inner-wrap .cmp-job-post__meta {
     grid-column: 2 / span 2;
+    position: sticky;
+    top: 2rem;
   }
   
   .job-posts .cmp-job-post__inner-wrap .cmp-job-post__details {


### PR DESCRIPTION
Adds `position: sticky` at mobile+ sizes to Job details meta container.

Closes #70 

## Description

URL for testing:

- https://feat--sticky-job-meta--design-website--adobe.hlx3.page/

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
