### PR TITLE
refactor: page title

### DIFF
--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -1,7 +1,6 @@
 .toolkit .cards-container {
   background-color: transparent;
   margin: 0 auto;
-  padding-top: 4rem;
   width: var(--content-width);
   max-width: var(--layout-max-width-desktop);   
 }
@@ -27,15 +26,10 @@
   display: grid;
   grid-template-columns: repeat(6, [col-start] 1fr);
   column-gap: 12px;
-  margin-bottom: 4rem;
-  padding-top: 5rem;
 }
 
-.cmp-inclusive__title-wrap h1 {
-  --page-title-font-size: var(--font-size-900);
-
-  font-size: var(--page-title-font-size);
-  margin-bottom: 2rem;
+.cmp-inclusive__title-wrap .page-title {
+  margin: var(--page-title-top-space) 0;
 }
 
 .cmp-inclusive__bg {
@@ -60,13 +54,9 @@
   width: 100%;
 }
 
-.cmp-cards__inner-wrap h1 {
-  --page-title-font-size: var(--font-size-900);
-
-  color: var(--reactive-text-color);
+.cmp-cards__inner-wrap .page-title {
   grid-column: 2 / -2;
-  font-size: var(--page-title-font-size);
-  margin: 2rem 0;
+  margin: var(--page-title-top-space) 0;
 }
 
 .cmp-cards__inner-wrap > h2 { 
@@ -75,10 +65,14 @@
   color: var(--reactive-text-color);
   font-family: var(--font-stack-serif);
   font-size: var(--page-subhead-font-size);
-  font-weight: 100;
+  font-weight: var(--font-weight-normal);
   grid-column: 2 / -2;
   margin-bottom: 4rem;
   line-height: 1.2;
+}
+
+.cmp-cards__inner-wrap .page-title + h2 {
+  margin-top: calc(var(--page-title-space-between-sub-title) / 2 * -1);
 }
 
 h2.cmp-inclusive__headline--secondary {
@@ -186,7 +180,6 @@ p.cmp-inclusive__intro {
 
   .cmp-inclusive__title-wrap {
     grid-template-columns: repeat(12, [col-start] 1fr);
-    padding-top: 5rem;
   }
 
   .cmp-inclusive__bg {
@@ -216,21 +209,12 @@ p.cmp-inclusive__intro {
   }
 
   .cmp-inclusive__title-wrap h1 {
-    --page-title-font-size: var(--font-size-2500);
-
-    padding: 10rem 0 25rem;
+    padding: 0 0 20rem;
   }
 
   p.cmp-inclusive__intro {
     --intro-font-size: var(--font-size-800);
 
-    margin-bottom: 4rem;
-  }
-
-  .cmp-cards__inner-wrap h1 {
-    --page-title-font-size: var(--font-size-2500);
-
-    margin-top: 6rem;
     margin-bottom: 4rem;
   }
 
@@ -301,20 +285,14 @@ p.cmp-inclusive__intro {
   .cards.block {
     grid-template-columns: repeat(16, [col-start] 1fr);
   }
-  
-  .cmp-cards__inner-wrap h1 {
-    --page-title-font-size: var(--font-size-4000);
-  }
-  
+
   .cmp-cards__inner-wrap > h2 { 
     --page-subhead-font-size: var(--font-size-950);
 
     grid-column: 2 / span 10;
   }
 
-  .cmp-inclusive__title-wrap h1 {
-    --page-title-font-size: var(--font-size-4000);
-
+  .cmp-inclusive__title-wrap .page-title {
     padding-right: 7rem;
     padding-left: 7rem;
   }

--- a/blocks/cards/cards.js
+++ b/blocks/cards/cards.js
@@ -68,6 +68,7 @@ function decorateInclusiveDesignPage(block) {
 }
 
 export default async function decorate(block) {
+  document.querySelector('h1').classList.add('page-title');
   const pathnames = [...block.querySelectorAll('a')].map((a) => new URL(a.href).pathname);
   block.textContent = '';
   const cards = await lookupPages(pathnames);

--- a/blocks/lede/lede.css
+++ b/blocks/lede/lede.css
@@ -9,7 +9,6 @@
   display: grid;
   grid-template-columns: repeat(6, [col-start] 1fr);
   column-gap: 12px;
-  padding-top: 5rem;
 }
 
 .cmp-lede__article-bg {
@@ -188,12 +187,7 @@
   margin-top: 2.5rem;
 }
 
-.cmp-lede__title {
-  --lede-title-font-size: var(--font-size-900);
-  
-  color: var(--reactive-text-color);
-  font-size: var(--lede-title-font-size);
-  line-height: 1;
+.page-title {
   margin-bottom: 2rem;
 }
 
@@ -214,6 +208,7 @@
   color: var(--reactive-text-color);
   display: inline-block;
   font-size: var(--lede-tag-font-size);
+  margin-top: 2rem;
   margin-bottom: 2rem;
   padding-bottom: 5px;
   position: relative;
@@ -250,18 +245,15 @@ p.cmp-lede__hero-parent {
   }
 
   .cmp-lede__article-title-wrap {
-    padding: 10rem 0 25rem;
+    padding: 5rem 0 25rem;
   }
 
   .cmp-lede__article-bg > * {
     grid-column: col-start 3 / span 8;
   }
 
-  .cmp-lede__title {
-    --lede-title-font-size: var(--font-size-2500);
-
+  .page-title {
     grid-column: col-start 2 / span 8;
-    line-height: 0.95;
   }
   
   .cmp-lede__intro {
@@ -410,9 +402,7 @@ p.cmp-lede__hero-parent {
     grid-column: col-start 4 / span 10;
   }
 
-  .cmp-lede__title {
-    --lede-title-font-size: var(--font-size-4000);
-
+  .page-title {
     grid-column: col-start 2 / span 12;
   }
 

--- a/blocks/lede/lede.js
+++ b/blocks/lede/lede.js
@@ -39,7 +39,7 @@ export default async function decorate(block) {
 
   articleComponent.classList.add('cmp-lede');
   articleInnerWrap.classList.add('cmp-lede__inner-wrap');
-  articleTitle.classList.add('cmp-lede__title');
+  articleTitle.classList.add('page-title');
 
   if (articleSubTitle.tagName === 'H2') {
     articleSubTitle.classList.add('cmp-lede__sub-title');

--- a/blocks/opportunities/opportunities.css
+++ b/blocks/opportunities/opportunities.css
@@ -1,7 +1,6 @@
 .jobs .section-wrapper {
   background-color: transparent;
   margin: 0 auto;
-  padding-top: 4rem;
   width: var(--content-width);
   max-width: var(--layout-max-width-desktop); 
 }
@@ -13,11 +12,8 @@
   row-gap: 12px;
 }
 
-.jobs .cmp-page__title {
-  --jobs-page-title-font-size: var(--font-size-900);
-
-  font-size: var(--jobs-page-title-font-size);
-  margin-bottom: 2rem;
+.jobs .page-title {
+  margin: var(--page-title-top-space) 0;
 }
 
 .jobs .cmp-page__intro {
@@ -114,10 +110,6 @@
   text-decoration: none;
 }
 
-.jobs .cmp-job__department {
-  /* margin-top: 0.15rem; */
-}
-
 .jobs .cmp-job__department,
 .jobs .cmp-job__location {
   font-size: var(--font-size-100);
@@ -128,10 +120,7 @@
     grid-template-columns: repeat(12, [col-start] 1fr);
   }
 
-  .jobs .cmp-page__title {
-    --jobs-page-title-font-size: var(--font-size-2500);
-    
-    margin-bottom: 4rem;
+  .jobs .page-title {
     grid-column: 2 / -2;
   }
   
@@ -175,10 +164,6 @@
 @media (min-width: 1300px) {
   .jobs .cmp-jobs-list__inner-wrap {
     grid-template-columns: repeat(16, [col-start] 1fr);
-  }
-
-  .jobs .cmp-page__title {
-    --jobs-page-title-font-size: var(--font-size-4000);
   }
 
   .jobs .cmp-page__intro {

--- a/blocks/opportunities/opportunities.js
+++ b/blocks/opportunities/opportunities.js
@@ -1,6 +1,6 @@
 export default async function decorate(block) {
   const pageTitle = document.querySelector('h1');
-  pageTitle.classList.add('cmp-page__title');
+  pageTitle.classList.add('page-title');
 
   block.parentNode.classList.add('cmp-jobs-list__inner-wrap');
 

--- a/blocks/story-feed/story-feed.css
+++ b/blocks/story-feed/story-feed.css
@@ -1,9 +1,5 @@
-.cmp-stories__inner-wrap h1 {
-  --stories-page-title-font-size: var(--font-size-900);
-
-  color: var(--reactive-text-color);
-  font-size: var(--stories-page-title-font-size);
-  margin: 2rem auto;
+.cmp-stories__inner-wrap .page-title {
+  margin: var(--page-title-top-space) auto;
   padding-right: 3.5rem;
   padding-left: 3.5rem;
   width: var(--content-width);
@@ -38,13 +34,6 @@
 }
 
 @media (min-width: 900px) {
-  .cmp-stories__inner-wrap h1 {
-    --stories-page-title-font-size: var(--font-size-2500);
-
-    margin-top: 6rem;
-    margin-bottom: 6rem;
-  }
-
   .cmp-stories__inner-wrap .story-feed {
     grid-template-columns: repeat(12, [col-start] 1fr);
   }
@@ -131,10 +120,4 @@
   font-size: var(--card-author-title-font-size);
   line-height: 1.3;
   margin-bottom: 0;
-}
-
-@media (min-width: 1300px) {
-  .cmp-stories__inner-wrap h1 {
-    --stories-page-title-font-size: var(--font-size-4000);
-  }
 }

--- a/blocks/story-feed/story-feed.css
+++ b/blocks/story-feed/story-feed.css
@@ -33,20 +33,6 @@
   object-fit: cover;
 }
 
-@media (min-width: 900px) {
-  .cmp-stories__inner-wrap .story-feed {
-    grid-template-columns: repeat(12, [col-start] 1fr);
-  }
-
-  .cmp-stories-card:nth-of-type(odd) {
-    grid-column: col-start 1 / span 6;
-  }
-
-  .cmp-stories-card:nth-of-type(even) {
-    grid-column: col-start 7 / span 6;
-  }
-}
-
 .cmp-stories-card__body {
   padding: 2.25rem 3.5rem;
 }
@@ -78,12 +64,6 @@
   margin: 1rem 0 1.5rem;
 }
 
-@media (min-width: 900px) {
-  .cmp-stories-card__title {
-    line-height: 1;
-  }
-}
-
 .cmp-stories-card__title a,
 .cmp-stories-card__title a:hover,
 .cmp-stories-card__title a:focus {
@@ -91,18 +71,12 @@
 }
 
 .cmp-stories-card__intro {
-  --card-intro-font-size: var(--font-size-400);
+  --card-intro-font-size: var(--font-size-650);
   
   font-family: var(--font-stack-serif);
   font-size: var(--card-intro-font-size);
   line-height: 1.3;
   margin-bottom: 1.5rem;
-}
-
-@media (min-width: 900px) {
-  .cmp-stories-card__intro {
-    --card-intro-font-size: var(--font-size-650);
-  }
 }
 
 .cmp-stories-card__author {
@@ -120,4 +94,22 @@
   font-size: var(--card-author-title-font-size);
   line-height: 1.3;
   margin-bottom: 0;
+}
+
+@media (min-width: 900px) {
+  .cmp-stories-card__title {
+    line-height: 1;
+  }
+
+  .cmp-stories__inner-wrap .story-feed {
+    grid-template-columns: repeat(12, [col-start] 1fr);
+  }
+
+  .cmp-stories-card:nth-of-type(odd) {
+    grid-column: col-start 1 / span 6;
+  }
+
+  .cmp-stories-card:nth-of-type(even) {
+    grid-column: col-start 7 / span 6;
+  }
 }

--- a/blocks/story-feed/story-feed.js
+++ b/blocks/story-feed/story-feed.js
@@ -28,6 +28,7 @@ function createCard(row) {
 }
 
 export default async function decorate(block) {
+  document.querySelector('h1').classList.add('page-title');
   const config = readBlockConfig(block);
   const pathnames = config.featured ? config.featured.map((link) => new URL(link).pathname) : [];
   block.textContent = '';

--- a/blocks/team-accordion/team-accordion.css
+++ b/blocks/team-accordion/team-accordion.css
@@ -3,7 +3,6 @@
 }
 
 .team-accordion-container {
-  padding: 5rem 0;
   margin: 0 auto;
   width: var(--content-width);
   max-width: var(--layout-max-width-desktop); 
@@ -17,14 +16,10 @@
   row-gap: 12px;
 }
 
-.team-accordion-container > h1 {
-  --title-font-size: var(--font-size-900);
-
+.team-accordion-container .page-title {
   grid-column: 2 / -2;
   color: var(--color-base-white);
-  font-size: var(--title-font-size);
-  line-height: var(--title-line-height);
-  margin-bottom: 4rem;
+  margin: var(--page-title-top-space) 0;
 }
 
 /* the actual accordions */
@@ -79,10 +74,8 @@
     grid-template-columns: repeat(12, [col-start] 1fr);
   }
 
-  .team-accordion-container > h1 {
-    --title-font-size: var(--font-size-2500);
-
-    grid-column: 2 / span 7;
+  .team-accordion-container .page-title {
+    grid-column: 2 / -2;
   }
 
   .cmp-accordion-container__inner > h2 {
@@ -113,10 +106,8 @@
     grid-template-columns: repeat(16, [col-start] 1fr);
   }
 
-  .team-accordion-container > h1 {
-    --title-font-size: var(--font-size-4000);
-
-    grid-column: 3 / span 9;
+  .team-accordion-container .page-title {
+    grid-column: 3 / -3;
   }
 
   .cmp-accordion-container__inner > h2 {

--- a/blocks/team-accordion/team-accordion.js
+++ b/blocks/team-accordion/team-accordion.js
@@ -215,27 +215,6 @@ export default async function decorate(block) {
     card.classList.add(`color-pair-${index + 1}`);
   });
 
-  // const orgHeadline = accordionGroup.nextElementSibling;
-  // if (orgHeadline.tagName === 'H2') {
-  //   orgHeadline.classList.add('cmp-org__headline');
-  // }
-
-  // const nextSiblings = (elem) => {
-  //   const siblings = [];
-  //   // eslint-disable-next-line no-cond-assign, no-param-reassign
-  //   while (elem = elem.nextElementSibling) {
-  //     siblings.push(elem);
-  //   }
-  //   return siblings;
-  // };
-
-  // const orgTextElems = nextSiblings(orgHeadline);
-  // const orgContainer = document.createElement('div');
-  // orgContainer.classList.add('cmp-org__container');
-  // orgContainer.append(orgHeadline);
-  // orgContainer.append(...orgTextElems);
-  // document.querySelector('.cmp-accordion-container__inner').append(orgContainer);
-
   const accordion = new Accordion();
   accordion.init();
   setTimeout(() => loadAccordion(accordion), 4000);

--- a/blocks/team-accordion/team-accordion.js
+++ b/blocks/team-accordion/team-accordion.js
@@ -188,6 +188,7 @@ export default async function decorate(block) {
   accordionContainer.firstChild.classList.add('cmp-accordion-container__inner');
   const pageTitle = accordionContainer.querySelector('h1');
   const pageTitleClone = pageTitle.cloneNode(true);
+  pageTitleClone.classList.add('page-title');
   accordionContainer.insertBefore(pageTitleClone, accordionContainer.firstChild);
   pageTitle.remove();
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -739,7 +739,7 @@ async function decorateJobPost() {
   const childrenToWrap = [...jobPostInnerWrap.children].slice(1);
 
   jobPostInnerWrap.innerHTML = `
-    <h1 class="cmp-job-post__title">${jobTitle}</h1>
+    <h1 class="page-title">${jobTitle}</h1>
     <aside class="cmp-job-post__meta">
       <a class="cmp-job-post__meta-link" href="${applyLink}">Apply now</a>
       <dl class="cmp-job-post__meta-list">

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -83,6 +83,22 @@
   --carousel-transition-ease: ease-out;
   --title-line-height: 1;
   --subtitle-line-height: 1.1;
+  --page-title-font-size: var(--font-size-900);
+  --page-title-line-height: 1.2;
+  --page-title-top-space: 5rem;
+}
+
+@media (min-width: 900px) {
+  :root {
+    --page-title-font-size: var(--font-size-2500);
+    --page-title-top-space: 10rem;
+  }
+}
+
+@media (min-width: 1300px) {
+  :root {
+    --page-title-font-size: var(--font-size-4000);
+  }
 }
 
 *, *::before, *::after {
@@ -122,9 +138,18 @@ input, button, textarea, select {
 
 h1 {
   /* h1s are Adobe Clean Black */
+  line-height: 1;
+}
+
+.page-title {
+  font-size: var(--page-title-font-size);
+  line-height: var(--page-title-line-height);
+}
+
+h1,
+.page-title {
   font-family: var(--font-stack-sans);
   font-weight: var(--font-weight-black);
-  line-height: 1;
 }
 
 /* above the fold CSS goes here to squash CLS */

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -148,8 +148,9 @@ h1 {
   color: var(--reactive-text-color);
   font-size: var(--page-title-font-size);
   line-height: var(--page-title-line-height);
-  /* handle margin on a case-by-case-basis in blocks */
-  /* --page-title-top-space is available for spacing */
+
+  /* handle margin on a case-by-case-basis in blocks
+  --page-title-top-space is available for spacing */
 }
 
 h1,

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -87,12 +87,14 @@
   --page-title-line-height: 1.1;
   --page-title-top-space: 5rem;
   --page-title-bottom-space: var(--page-title-top-space);
+  --page-title-space-between-sub-title: 4rem;
 }
 
 @media (min-width: 900px) {
   :root {
     --page-title-font-size: var(--font-size-2500);
     --page-title-top-space: 10rem;
+    --page-title-space-between-sub-title: 6rem;
   }
 }
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -84,8 +84,9 @@
   --title-line-height: 1;
   --subtitle-line-height: 1.1;
   --page-title-font-size: var(--font-size-900);
-  --page-title-line-height: 1.2;
+  --page-title-line-height: 1.1;
   --page-title-top-space: 5rem;
+  --page-title-bottom-space: var(--page-title-top-space);
 }
 
 @media (min-width: 900px) {
@@ -142,8 +143,11 @@ h1 {
 }
 
 .page-title {
+  color: var(--reactive-text-color);
   font-size: var(--page-title-font-size);
   line-height: var(--page-title-line-height);
+  /* handle margin on a case-by-case-basis in blocks */
+  /* --page-title-top-space is available for spacing */
 }
 
 h1,

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -261,12 +261,8 @@ body.job-posts {
   grid-column: 2 / -2;
 }
 
-.job-posts .cmp-job-post__inner-wrap h1 {
-  --page-title-font-size: var(--font-size-900);
-
-  color: var(--reactive-text-color);
-  font-size: var(--page-title-font-size);
-  margin: 6rem 0 3rem;
+.job-posts .cmp-job-post__inner-wrap .page-title {
+  margin: var(--page-title-top-space) 0;
 }
 
 .cmp-jobs-stats-container__inner-wrap > h2,
@@ -504,11 +500,7 @@ body.job-posts {
   }
 
   .job-posts .cmp-job-post__inner-wrap h1 {
-    --page-title-font-size: var(--font-size-2500);
-
     grid-column: 6 / -2;
-    margin-top: 6rem;
-    margin-bottom: 4rem;
   }
 
   .job-posts .cmp-about-ad-container h2 {
@@ -591,10 +583,7 @@ body.job-posts {
   }
 
   .job-posts .cmp-job-post__inner-wrap h1 {
-    --page-title-font-size: var(--font-size-4000);
-
     grid-column: 7 / -2;
-    margin-bottom: 6rem;
   }
 
   .job-posts .cmp-job-post__inner-wrap .cmp-job-post__details h2 {


### PR DESCRIPTION
Major refactor of all page titles (`h1`).

* creates common `.page-title` selector styles
* creates custom props to support `.page-title`
* adds new selector to `h1` elements, site-wide

Closes #114, Closes #93 

## Description

URL for testing:

- https://refactor-page-title--design-website--adobe.hlx3.page/

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
