### PR TITLE
fix: images overflowing on toolkit and inclusive design pages

### DIFF
--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -5,6 +5,13 @@
   max-width: var(--layout-max-width-desktop);   
 }
 
+.toolkit.inclusive-design .cards-container {
+  background-color: transparent;
+  margin: auto;
+  width: auto;
+  max-width: none;   
+}
+
 .cmp-cards__inner-wrap {
   display: grid;
   grid-template-columns: repeat(6, [col-start] 1fr);
@@ -146,11 +153,9 @@ p.cmp-inclusive__intro {
 }
 
 .cards .cmp-cards-card__title {
-  --home-card-title-font-size: var(--font-size-900);
-
-  font-size: var(--home-card-title-font-size);
+  font-size: min(max(var(--font-size-800), 4vw), var(--font-size-1000));
   font-weight: var(--font-weight-black);
-  margin: 1rem 0;
+  margin: 1rem 0 1.5rem;
 }
 
 .cards .cmp-cards-card__description {
@@ -164,6 +169,7 @@ p.cmp-inclusive__intro {
 
 .cards .cmp-cards-card__media {
   aspect-ratio: 1 / 1;
+  overflow: hidden;
 }
   
 .cards .cmp-cards-card__media img {
@@ -261,10 +267,7 @@ p.cmp-inclusive__intro {
   }
 
   .cards .cmp-cards-card__title {
-    --home-card-title-font-size: var(--font-size-1000); 
-
     line-height: 1.1;
-    margin-bottom: 2rem;
   }
 }
 

--- a/blocks/collaborators/collaborators.css
+++ b/blocks/collaborators/collaborators.css
@@ -1,13 +1,12 @@
 .collaborators {
   background-color: var(--color-base-light-rose);
   grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: repeat(6, [col-start] 1fr);
 }
 
 .cmp-collaborators__inner-wrap {
-  display: grid;
-  grid-template-columns: repeat(6, [col-start] 1fr);
-  column-gap: 12px;
-  row-gap: 12px;
+  grid-column: 2 / -2;
   padding-top: 4rem;
 }
 
@@ -18,6 +17,7 @@
 
 .cmp-collaborator picture {
   aspect-ratio: 1 / 1;
+  overflow: hidden;
 }
 
 .cmp-collaborator img {
@@ -81,6 +81,9 @@
   
   .cmp-collaborators__inner-wrap {
     grid-column: 2 / -2;
+    column-gap: 12px;
+    row-gap: 12px;
+    display: grid;
     grid-template-columns: 1fr 1fr 1fr;
   }
 


### PR DESCRIPTION
This writes CSS to prevent image overflows on both the Toolkit landing page and on the Inclusive Design page. It also specifies an aspect ratio for profile photos.

Closes #131

URL for testing:

- https://fix-toolkit-inclusive-design--design-website--adobe.hlx3.page/

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
