### PR TITLE
chore: better redirect handling for authoring

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -593,8 +593,26 @@ export function decorateMain(main) {
 async function loadEager(doc) {
   const redirect = getMetadata('redirect');
   const usp = new URLSearchParams(window.location.search);
-  if (redirect && !usp.has('suppress-redirect')) {
-    window.location.href = redirect;
+  if (redirect) {
+    if (!usp.get('redirect') && (window.location.hostname.endsWith('localhost') || window.location.hostname.endsWith('.page') || window.location.hostname.endsWith('.live'))) {
+      const redirectBanner = document.createElement('div');
+      redirectBanner.innerHTML = `Redirect set to <a href="${redirect}">${redirect}</a>`;
+      redirectBanner.setAttribute('style', `
+      background-color: #ddd;
+      color: #222;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      padding: 16px;
+      position: fixed;
+      z-index: 1;
+      display: block;
+      `);
+      document.querySelector('main').prepend(redirectBanner);
+    } else {
+      window.location.href = redirect;
+      return;
+    }
   }
 
   const main = doc.querySelector('main');


### PR DESCRIPTION
currently it is relatively hard to handle pages that have a redirect on them for authors, as the pages get redirected as soon as they are (pre)viewed, which makes it hard to `publish`. this new way of redirect handling automatically suppresses the redirect on `.page` and `.live` URLs and only actually redirects on the production URL...

https://better-redirect--design-website--adobe.hlx3.page/toolkit/inclusive-design-card

...to test the redirect behavior in production...

https://better-redirect--design-website--adobe.hlx3.page/toolkit/inclusive-design-card?redirect=on 

can be used.