### PR TITLE
chore: specific order on jobs landing, remove homepage job position types

### DIFF
--- a/blocks/jobs/jobs.js
+++ b/blocks/jobs/jobs.js
@@ -4,7 +4,7 @@ function createJob(job) {
   const jobItem = document.createElement('li');
   jobItem.classList.add('cmp-jobs-list__item');
   jobItem.innerHTML = `
-    <a class="cmp-job__link" href="${job.path}">${job.title} (${job.positionType})</a>
+    <a class="cmp-job__link" href="${job.path}">${job.title}</a>
     <p class="cmp-job__department">${job.department}</p>
     <p class="cmp-job__location">${job.location}</p>
   `;

--- a/blocks/opportunities/opportunities.css
+++ b/blocks/opportunities/opportunities.css
@@ -147,13 +147,19 @@
   }
 
   .cmp-all-jobs {
-    columns: 2;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
     column-gap: 200px;
+    row-gap: 0;
   }
 
-  .cmp-job__group {
-    display: inline-block;
-    width: 100%;
+  .cmp-job__group:first-of-type {
+    /*
+      this is a hack to get the "experience design" column to always show first
+      and to take up its own column *without* resorting to some kind of js solution.
+    */
+
+    grid-row: 1 / 50;
   }
 
   .cmp-job__group-title {


### PR DESCRIPTION
On the `/jobs/` landing page, this forces "experience design" positions to be listed in the first column, and the remaining positions to be listed in the second column. Closes #171 

Additionally, this removes the "position type" designation on job listings on the homepage.

## Description

URL for testing:

- https://chore-opportunities-columns--design-website--adobe.hlx3.page/

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
