### PR TITLE
fix: use different data source for author name in author details block

### DIFF
--- a/blocks/lede/lede.js
+++ b/blocks/lede/lede.js
@@ -72,7 +72,9 @@ export default async function decorate(block) {
   articleAttributionContainer.classList.add('cmp-lede__attribution');
   articleAttributionContainer.innerHTML = html;
 
-  const authorName = (articleAttributionContainer.querySelector('h1') !== null)
+  const authorTextContent = articleAttributionContainer.querySelector('h1').textContent;
+
+  const authorName = (authorTextContent !== null && authorTextContent !== '')
     ? `<p class="cmp-lede__author">${articleAttributionContainer.querySelector('h1').textContent}</p>` : '';
 
   const authorTitle = (articleAttributionContainer.querySelector('h2') !== null)
@@ -106,10 +108,13 @@ export default async function decorate(block) {
     publishedDate.classList.add('cmp-author-details__pub-date');
     publishedDate.innerHTML = getMetadata('publication-date');
 
+    // need to use authorTextContent below because
+    // getMetadata('author') returns a sanitized string
+    // and some authors have special characters in their names
     authorDetailsBlock.innerHTML = `
       <div class="cmp-author-details__meta">
         ${authorDetailsPhoto}
-        <p class="cmp-author-details__name">${authorDetailsName}</p>
+        <p class="cmp-author-details__name">${authorTextContent}</p>
         ${authorDetailsTitle}
       </div>
       <div class="cmp-author-details__bio"></div>


### PR DESCRIPTION
This uses the data from the plain author query to populate the author's name, rather than using the meta tag, which was stripping out special characters from author names.

Closes #115

<!--- Provide a general summary of your changes in the Title above -->

## Description

URL for testing:

- https://fix-author-name-in-details--design-website--adobe.hlx3.page/
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
<img width="634" alt="Screen Shot 2022-03-12 at 2 23 24 PM" src="https://user-images.githubusercontent.com/360251/158032033-9b040e28-6c55-44e0-a826-e3c9f97d67e2.png">


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
