### PR TITLE
fix: prevent accordion overflow

### DIFF
--- a/blocks/team-accordion/team-accordion.css
+++ b/blocks/team-accordion/team-accordion.css
@@ -57,7 +57,7 @@
 
 .cmp-accordion-card {
   grid-column: 1 / -1;
-  padding: 3rem;
+  padding: 3.625rem;
   width: 100%;
   cursor: pointer;
 }
@@ -75,7 +75,7 @@
   font-size: var(--card-title-font-size);
   font-weight: normal;
   line-height: var(--title-line-height);
-  margin-bottom: 2rem;
+  margin-bottom: 3.0625rem;
   padding-bottom: 1rem;
   position: relative;
   display: flex;

--- a/blocks/team-accordion/team-accordion.css
+++ b/blocks/team-accordion/team-accordion.css
@@ -24,9 +24,6 @@
 
 /* the actual accordions */
 .cmp-accordion__group {
-  display: grid;
-  grid-template-columns: repeat(6, [col-start] 1fr);
-  column-gap: 12px;
   position: relative;
 }
 
@@ -200,8 +197,6 @@
     --first-color-stop: 40%;
     --second-color-stop: 40%;
     --third-color-stop: 100%;
-
-    grid-template-columns: repeat(12, [col-start] 1fr);
   }
 
   .cmp-accordion-card {
@@ -299,8 +294,6 @@
     --first-color-stop: 50%;
     --second-color-stop: 50%;
     --third-color-stop: 100%;
-
-    grid-template-columns: repeat(16, [col-start] 1fr);
   }
 
   .cmp-accordion-card {


### PR DESCRIPTION
This removes a superfluous `grid` from the accordion container, and fixes an issue where text was overflowing and being cut off in Safari.

Closes #257
Closes #248 

<!--- Provide a general summary of your changes in the Title above -->

## Description

URL for testing:

- https://fix--accordion-overflow--design-website--adobe.hlx3.page/

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
