### PR TITLE
404 pages don't always show up for missing content

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -717,7 +717,7 @@ if (window.name.includes('performance')) registerPerformanceLogger();
 function addPathsAsClassNames() {
   if (window.location.pathname === '/') {
     document.body.classList.add('home');
-  } else if (window.location.pathname === '/404.html') {
+  } else if (document.title === 'Page Not Found') {
     document.body.classList.add('page-not-found', 'light-text');
   } else {
     const pathNames = window.location.pathname.toLowerCase().split('/').filter((item) => item !== '').slice(0, 2);


### PR DESCRIPTION
going to a url like:
https://adobe.design/jobs/job-posts/experience-design/r122213-sr-experience-designer

with missing content does not show the correct 404 page.

- https://404-issue--design-website--adobe.hlx.page/404.html