### PR TITLE
fix: replace innerHTML with textContent

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -13,7 +13,7 @@ indices:
       subtitle:
         select: main h1 + h2
         value: |
-          innerHTML(el)
+          textContent(el)
       author:
         select: head > meta[name="author"]
         value: |


### PR DESCRIPTION
`innerHTML` has been removed in the latest indexer HTML extraction engine.

I verified that the current index contents will look identical if `innerHTML` is replaced with `textContent`

For a verification of the culprit that recently occurred, compare:

https://admin.hlx.page/index/adobe/design-website/main/stories/our-people/hacks-hobbies-and-side-hustles-nitzan-klamer
(this is the version with `innerHTML` that no longer works)

https://admin.hlx.page/index/adobe/design-website/use-text-content/stories/our-people/hacks-hobbies-and-side-hustles-nitzan-klamer
(this is the version with `textContent` that works again and delivers the expected result)