### PR TITLE
feat: open links in articles in new tab

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -807,11 +807,20 @@ if (getMetadata('theme') === 'job-post') {
 }
 
 export function setTargetOnExternalLinks() {
-  [...document.querySelectorAll('a')].forEach((link) => (
-    window.location.hostname === link.hostname || !link.hostname.length ? false : link.setAttribute('target', '_blank')
-  ));
+  [...document.querySelectorAll('a')].forEach((link) => {
+    // Set external links to open in window or tab
+
+    if (window.location.hostname !== link.hostname || !link.hostname.length) {
+      link.setAttribute('target', '_blank');
+    }
+
+    // Set all links in a stories article contents to open in a new window or tab
+    if (link.closest('.lede-container') && window.location.href.toString().includes('/stories/')) {
+      link.setAttribute('target', '_blank');
+    }
+  });
 }
 
 setTimeout(() => {
   setTargetOnExternalLinks();
-}, 2500);
+}, 1500);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

URLs For testing:

- [Demo of Stories Article internal links that open in a new tab or window](https://sbx-internal-links-new-tab--design-website--adobe.hlx.page/stories/process/a-modern-adobe-acrobat)
- [Demo of Not-Stories page with internal links that open in the same tab](https://sbx-internal-links-new-tab--design-website--adobe.hlx.page/toolkit/inclusive-design/)


## Description

<!--- Describe your changes in detail -->

This work expands on the function which sets queries all links on a page and sets external links to open in a new tab, so that specific content areas links will open in a new tab for internal links as well.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
The original issue can be found on [Trello](https://trello.com/c/ul2Otvgy/10-open-internal-links-within-articles-in-a-new-tab)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Currently all external links site-wide open in a new tab/window. However to keep readers of articles from losing the original page, internal links on Stories  pages will open in a new tab window as well.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

The test links provided above were used and the DOM inspected to ensure a `target="_blank"` was added to only internal links with an ancestor container with a class of `.lede-container`.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
