### PR TITLE
feat: Add embed block for social media embeds

### DIFF
--- a/blocks/embed/embed.css
+++ b/blocks/embed/embed.css
@@ -8,19 +8,11 @@
 }
 
 .cmp-embed--instagram .instagram-media {
-  width: 80%;
-}
-
-.cmp-embed--instagram .cmp-embed__container {
-  justify-content: center;
+  width: 100%;
+  min-width: unset !important;
 }
 
 .cmp-embed--twitter .twitter-tweet {
   justify-content: center;
-}
-
-@media (min-width: 900px) {
-  .cmp-embed--instagram .instagram-media {
-    width: 100%;
-  }
+  margin: 0 !important;
 }

--- a/blocks/embed/embed.css
+++ b/blocks/embed/embed.css
@@ -1,0 +1,47 @@
+.cmp-embed {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+}
+
+.cmp-embed--instagram {
+  display: grid;
+  justify-content: unset;
+  margin: 0 0 2rem;
+}
+
+.cmp-embed--instagram figure {
+  display: flex;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.cmp-embed--instagram .instagram-media {
+  width: 75%;
+}
+
+.cmp-embed--twitter {
+  margin: 2rem 0;
+}
+
+@media (min-width: 600px) {
+  .cmp-embed--instagram {
+    margin-bottom: 4rem;
+  }
+
+  .cmp-embed--twitter {
+    margin: 2.625rem 0;
+  }
+}
+
+@media (min-width: 900px) {
+  .cmp-embed--twitter {
+    margin: 5.1875rem 0;
+  }
+}
+
+@media (min-width: 1300px) {
+  .cmp-embed--twitter {
+    margin: 10.375rem 0;
+  }
+}

--- a/blocks/embed/embed.css
+++ b/blocks/embed/embed.css
@@ -1,47 +1,26 @@
 .cmp-embed {
-  display: flex;
-  justify-content: center;
-  width: 100%;
+  margin: 5.25rem 0;
 }
 
-.cmp-embed--instagram {
-  display: grid;
-  justify-content: unset;
-  margin: 0 0 2rem;
-}
-
-.cmp-embed--instagram figure {
+.cmp-embed__container {
   display: flex;
   justify-content: center;
-  overflow: hidden;
 }
 
 .cmp-embed--instagram .instagram-media {
-  width: 75%;
+  width: 80%;
 }
 
-.cmp-embed--twitter {
-  margin: 2rem 0;
+.cmp-embed--instagram .cmp-embed__container {
+  justify-content: center;
 }
 
-@media (min-width: 600px) {
-  .cmp-embed--instagram {
-    margin-bottom: 4rem;
-  }
-
-  .cmp-embed--twitter {
-    margin: 2.625rem 0;
-  }
+.cmp-embed--twitter .twitter-tweet {
+  justify-content: center;
 }
 
 @media (min-width: 900px) {
-  .cmp-embed--twitter {
-    margin: 5.1875rem 0;
-  }
-}
-
-@media (min-width: 1300px) {
-  .cmp-embed--twitter {
-    margin: 10.375rem 0;
+  .cmp-embed--instagram .instagram-media {
+    width: 100%;
   }
 }

--- a/blocks/embed/embed.js
+++ b/blocks/embed/embed.js
@@ -1,0 +1,82 @@
+const EMBEDS_CONFIG = {
+  instagram: {
+    type: 'instagram',
+    url: 'https://www.instagram.com/embed.js',
+    createEmbed: (url) => {
+      const trailingSlash = url.endsWith('/') ? '' : '/';
+      const src = `${url}${trailingSlash}embed/`;
+
+      return `
+        <figure>
+          <blockquote
+            class="instagram-media"
+          >
+            <a href=${src}></a>
+          </blockquote>
+        </figure>
+      `;
+    },
+    onLoad: (wrapper) => {
+      const iframe = wrapper.querySelector('.instagram-media');
+      const iframeHeight = iframe.getAttribute('height');
+
+      // Height of Instagram footer content is 153px
+      iframe.setAttribute('height', (Number(iframeHeight) - 153).toString());
+
+      // Remove margin set by embed script
+      iframe.setAttribute('style', 'background-color: white; border-radius: 3px; border: 1px solid rgb(219, 219, 219); box-shadow: none; display: block; margin: 0; min-width: 326px; padding: 0px;');
+    },
+  },
+  twitter: {
+    type: 'twitter',
+    url: 'https://platform.twitter.com/widgets.js',
+    createEmbed: (url) => `
+      <blockquote class="twitter-tweet">
+        <a href=${url}></a>
+      </blockquote>
+    `,
+  },
+};
+
+const setConfig = (embedCode) => {
+  switch (true) {
+    case (embedCode.includes('instagram')):
+      return EMBEDS_CONFIG.instagram;
+    case (embedCode.includes('twitter')):
+      return EMBEDS_CONFIG.twitter;
+    default:
+      return null;
+  }
+};
+
+export default async function decorate(block) {
+  // Find the embed url
+  const url = block.querySelector('div') !== null ? block.querySelector('div').innerText : null;
+
+  // Set config
+  const config = setConfig(url);
+
+  // Create wrapper div for embed and set innerHTML to embed code
+  const createWrapper = document.createElement('div');
+  const createEmbed = config.createEmbed(url);
+  createWrapper.className = `cmp-embed cmp-embed--${config.type}`;
+  createWrapper.innerHTML = createEmbed;
+  block.parentNode.insertBefore(createWrapper, block);
+  block.remove();
+
+  // Import script into head
+  const createScript = document.createElement('script');
+  createScript.setAttribute('src', config.url);
+  document.querySelector('head').append(createScript);
+
+  // Clean up functions
+  setTimeout(() => {
+    if (config.onLoad) {
+      config.onLoad(createWrapper);
+
+      window.addEventListener('resize', () => {
+        config.onLoad(createWrapper);
+      });
+    }
+  }, 1000);
+}

--- a/blocks/embed/embed.js
+++ b/blocks/embed/embed.js
@@ -7,32 +7,25 @@ const EMBEDS_CONFIG = {
       const src = `${url}${trailingSlash}embed/`;
 
       return `
-        <figure>
+        <figure class="cmp-embed__container">
           <blockquote
             class="instagram-media"
+            data-instgrm-captioned
           >
             <a href=${src}></a>
           </blockquote>
         </figure>
       `;
     },
-    onLoad: (wrapper) => {
-      const iframe = wrapper.querySelector('.instagram-media');
-      const iframeHeight = iframe.getAttribute('height');
-
-      // Height of Instagram footer content is 153px
-      iframe.setAttribute('height', (Number(iframeHeight) - 153).toString());
-
-      // Remove margin set by embed script
-      iframe.setAttribute('style', 'background-color: white; border-radius: 3px; border: 1px solid rgb(219, 219, 219); box-shadow: none; display: block; margin: 0; min-width: 326px; padding: 0px;');
-    },
   },
   twitter: {
     type: 'twitter',
     url: 'https://platform.twitter.com/widgets.js',
     createEmbed: (url) => `
-      <blockquote class="twitter-tweet">
-        <a href=${url}></a>
+      <blockquote class="cmp-embed__container">
+        <blockquote class="twitter-tweet">
+          <a href=${url}></a>
+        </blockquote>
       </blockquote>
     `,
   },
@@ -59,8 +52,8 @@ export default async function decorate(block) {
   // Create wrapper div for embed and set innerHTML to embed code
   const createWrapper = document.createElement('div');
   const createEmbed = config.createEmbed(url);
-  createWrapper.className = `cmp-embed cmp-embed--${config.type}`;
   createWrapper.innerHTML = createEmbed;
+  createWrapper.className = `cmp-embed cmp-embed--${config.type}`;
   block.parentNode.insertBefore(createWrapper, block);
   block.remove();
 
@@ -68,15 +61,4 @@ export default async function decorate(block) {
   const createScript = document.createElement('script');
   createScript.setAttribute('src', config.url);
   document.querySelector('head').append(createScript);
-
-  // Clean up functions
-  setTimeout(() => {
-    if (config.onLoad) {
-      config.onLoad(createWrapper);
-
-      window.addEventListener('resize', () => {
-        config.onLoad(createWrapper);
-      });
-    }
-  }, 1000);
 }

--- a/blocks/embed/embed.js
+++ b/blocks/embed/embed.js
@@ -6,6 +6,7 @@ const EMBEDS_CONFIG = {
       const trailingSlash = url.endsWith('/') ? '' : '/';
       const src = `${url}${trailingSlash}embed/`;
 
+      // Embed script replaces nested blockquote
       return `
         <figure class="cmp-embed__container">
           <blockquote
@@ -21,6 +22,7 @@ const EMBEDS_CONFIG = {
   twitter: {
     type: 'twitter',
     url: 'https://platform.twitter.com/widgets.js',
+    // Embed script replaces nested blockquote
     createEmbed: (url) => `
       <blockquote class="cmp-embed__container">
         <blockquote class="twitter-tweet">


### PR DESCRIPTION
## Description

Similarly to #301, this PR creates a block for displaying embeds from social media, such as Instagram and Twitter. The block is called `embed` and expects the first and only table cell to contain the link to a social media post.

## Motivation and Context

This will allow content creators to link add social media posts to stories.

## How Has This Been Tested?

Tested on a demo page to preview the feature: https://sbx-social-media-embeds--design-website--adobe.hlx.page/drafts/dev/embed-draft

## Screenshots (if appropriate):

<img width="1512" alt="Screen Shot 2022-08-03 at 3 03 49 PM" src="https://user-images.githubusercontent.com/53844657/182720680-5bac5f4d-046b-40b5-aa7f-14b986508603.png">

<img width="1512" alt="Screen Shot 2022-08-03 at 3 04 09 PM" src="https://user-images.githubusercontent.com/53844657/182720697-333c7c10-c406-4ad6-af8d-665fc5683fd1.png">

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
