### PR TITLE
chore: Add sitemap

### DIFF
--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -1,0 +1,12 @@
+version: 1
+
+sitemaps:
+  website:
+    origin: https://adobe.design/
+    lastmod: YYYY-MM-DD
+    languages:
+      default:
+        source: /query-index.json
+        destination: /sitemap.xml
+        hreflang: en
+        alternate: /{path}


### PR DESCRIPTION
## Description

This PR adds a file `helix-sitemap.yaml`.

## Motivation and Context

No sitemap generated for https://adobe.design.

## How Has This Been Tested?

Demo preview: https://sbx-add-sitemap--design-website--adobe.hlx.page/

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
