### PR TITLE
feat: Add images block for side-by-side image embeds

### DIFF
--- a/blocks/multi-image/multi-image.css
+++ b/blocks/multi-image/multi-image.css
@@ -1,0 +1,55 @@
+.cmp-multi-image {
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-gap: 2rem 12px;
+  margin: 4rem auto;
+}
+
+.cmp-multi-image__image picture {
+  aspect-ratio: 4 / 3;
+}
+
+.cmp-multi-image__image:not(:last-child) picture:last-child {
+  margin-bottom: 1.5rem;
+}
+
+.cmp-multi-image__image picture img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center;
+}
+
+.cmp-multi-image__caption {
+  margin-top: 1rem;
+  font-size: var(--font-size-100);
+}
+
+@media (min-width: 600px) {
+  .cmp-multi-image--2-up {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (min-width: 900px) {
+  .cmp-multi-image {
+    margin: 8.875rem auto;
+  }
+
+  .cmp-lede__article-bg > .cmp-multi-image--2-up {
+    grid-column: 2 / -2;
+  }
+
+  .cmp-lede__article-bg > .cmp-multi-image--3-up {
+    grid-template-columns: repeat(3, 1fr);
+    grid-column: 2 / -2;
+  }
+}
+
+@media (min-width: 1300px) {
+  .cmp-lede__article-bg > .cmp-multi-image--2-up,
+  .cmp-lede__article-bg > .cmp-multi-image--3-up {
+    grid-column: 3 / -3;
+  }
+}

--- a/blocks/multi-image/multi-image.js
+++ b/blocks/multi-image/multi-image.js
@@ -1,0 +1,50 @@
+const SIDE_BY_SIDE_MODIFIER_CLASS = {
+  2: 'cmp-multi-image--2-up',
+  3: 'cmp-multi-image--3-up',
+};
+
+export default function decorate(block) {
+  const container = block.querySelector('div');
+  const imageBlocks = container.querySelectorAll('div');
+
+  // 2-up or 3-up
+  let modifier = SIDE_BY_SIDE_MODIFIER_CLASS[imageBlocks.length];
+  if (!modifier) modifier = '';
+
+  // Generate HTML for images
+  let createImages = '';
+  imageBlocks.forEach((imageBlock) => {
+    const image = imageBlock.querySelector('div > :first-child');
+    const caption = imageBlock.querySelector('p:last-child');
+
+    let imageHTML = image.innerHTML;
+    if (!image.querySelector('picture')) {
+      imageHTML = `<picture>${image.innerHTML}</picture>`;
+    }
+
+    let captionHTML;
+    if (!caption) captionHTML = '';
+    else {
+      captionHTML = `
+        <figcaption class="cmp-multi-image__caption">${caption.innerHTML}</figcaption>
+      `;
+    }
+
+    const generatedHTML = `
+      <figure class="cmp-multi-image__image">
+        ${imageHTML}
+        ${captionHTML}
+      </figure>
+    `;
+    createImages += generatedHTML;
+  });
+
+  // Create wrapper for images
+  const createWrapper = document.createElement('div');
+  createWrapper.className = `cmp-multi-image ${modifier}`;
+  createWrapper.innerHTML = createImages;
+  block.parentNode.insertBefore(createWrapper, block);
+
+  // Remove original block
+  block.remove();
+}


### PR DESCRIPTION
## Description

This PR creates a block for displaying two or three images side-by-side. The block is called `multi-image` and expects a single row with either two or three cells. Each cell includes an image and a caption. If less than two or more than three images are added, then the images stack on all screen sizes.

## Motivation and Context

This will allow content creators to display up to three images in a row in stories as needed.

## How Has This Been Tested?

Tested on a demo page to preview the feature: https://sbx-side-by-side-images--design-website--adobe.hlx.page/drafts/dev/images-draft

## Screenshots (if appropriate):

<img width="1512" alt="Screen Shot 2022-08-02 at 2 05 20 PM" src="https://user-images.githubusercontent.com/53844657/182473312-27a30345-a065-4b38-a022-dcfb113d236b.png">

<img width="1512" alt="Screen Shot 2022-08-02 at 2 05 46 PM" src="https://user-images.githubusercontent.com/53844657/182473341-ccc014b3-a910-4b2e-9361-59e18c516036.png">

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
