### PR TITLE
feat: Add stats block replacement

### DIFF
--- a/blocks/callout-numbers/callout-numbers.css
+++ b/blocks/callout-numbers/callout-numbers.css
@@ -1,0 +1,79 @@
+.cmp-callout-numbers {
+  width: var(--content-width);
+  max-width: var(--layout-max-width-desktop);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
+  align-items: center;
+  gap: 1rem;
+  background: #0070ed;
+  background: 
+    radial-gradient(
+      circle at top left,
+      #0070ed 0% 51%,
+      transparent 51% 100%
+    ),
+    #1a82f6;
+  color: var(--color-base-white);
+  margin: 1rem auto;
+  padding: 4rem 2rem;
+}
+
+.cmp-callout-numbers__item {
+  display: grid;
+  max-width: 40ch;
+  text-align: center;
+  line-height: 1;
+}
+
+.cmp-callout-numbers__item-number {
+  --stats-number-font-size: var(--font-size-2000);
+
+  margin-bottom: 1rem;
+  font-family: var(--font-stack-sans);
+  font-size: var(--stats-number-font-size);
+  font-weight: var(--font-weight-black);
+}
+
+.cmp-callout-numbers__item-description {
+  --stats-description-font-size: var(--font-size-100);
+
+  font-family: var(--font-stack-serif);
+  font-size: var(--stats-description-font-size);
+  text-transform: capitalize;
+}
+
+@media (min-width: 600px) {
+  .cmp-callout-numbers {
+    background: 
+      radial-gradient(
+        circle at top left,
+        #0070ed 0% 54%,
+        transparent 54% 100%
+      ),
+      #1a82f6;
+  }
+}
+
+@media (min-width: 900px) {
+  .cmp-callout-numbers {
+    flex-direction: row;
+    gap: unset;
+    background: 
+      radial-gradient(
+        circle at top left,
+        #0070ed 0% 51%,
+        transparent 51% 100%
+      ),
+      #1a82f6;
+    padding: 8rem 2rem;
+  }
+
+  .cmp-callout-numbers__item-number {
+    --stats-number-font-size: var(--font-size-4000);
+  }
+
+  .cmp-callout-numbers__item-description {
+    --stats-description-font-size: var(--font-size-300);
+  }
+}

--- a/blocks/callout-numbers/callout-numbers.js
+++ b/blocks/callout-numbers/callout-numbers.js
@@ -1,0 +1,18 @@
+export default async function decorate(block) {
+  // Create new section
+  const makeContainer = document.createElement('section');
+  makeContainer.className = 'cmp-callout-numbers';
+
+  // Apply classes to items (should have a number and a description)
+  const items = block.querySelectorAll(':scope > div');
+  items.forEach((item) => {
+    // Only consider data in first two columns
+    const [itemNumber, itemDescription] = item.childNodes;
+    itemNumber.className = 'cmp-callout-numbers__item-number';
+    itemDescription.className = 'cmp-callout-numbers__item-description';
+    makeContainer.innerHTML += `<div class="cmp-callout-numbers__item">${item.innerHTML}</div>`;
+  });
+
+  block.parentNode.insertBefore(makeContainer, block);
+  block.remove();
+}


### PR DESCRIPTION
## Description

This PR creates a new block, currently called `callout-numbers`, which will replace the existing `stats` block as can be seen on the homepage.

## Related Issue

[ADB-47](https://sparkbox.atlassian.net/browse/ADB-47)

## Motivation and Context

The existing block received new design direction. A new block was created to start to decouple the original `stats` block and `jobs` block, which were both added to a container on page load.

## How Has This Been Tested?

Tested on the preview page: https://sbx-stats-block-adjustment--design-website--adobe.hlx.page/drafts/dev/callout-numbers-draft

## Screenshots (if appropriate):

320px screen:
<img width="301" alt="Screen Shot 2022-08-10 at 8 57 12 AM" src="https://user-images.githubusercontent.com/53844657/183961360-5c66b6c4-6aea-4d39-bf8e-7afab5a8401d.png">

600px screen:
<img width="550" alt="Screen Shot 2022-08-10 at 8 57 40 AM" src="https://user-images.githubusercontent.com/53844657/183961488-eadbb1f7-3012-44d6-a1f9-81edec3d7fd3.png">

900px screen:
<img width="826" alt="Screen Shot 2022-08-10 at 8 58 00 AM" src="https://user-images.githubusercontent.com/53844657/183961517-18a79f5f-6f3a-48d5-90f3-a0a8d3bf1353.png">

1300px screen:
<img width="1181" alt="Screen Shot 2022-08-10 at 8 58 18 AM" src="https://user-images.githubusercontent.com/53844657/183961543-f094b416-7f08-47f8-b9f1-13b1b45e169d.png">

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
