### PR TITLE
fix: lookupPages sideeffect

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -518,7 +518,7 @@ loadPage(document);
 
 export async function lookupPages(pathnames) {
   if (!window.pageIndex) {
-    const resp = await fetch('/query-index.json');
+    const resp = await fetch('/query-index.json?sheet=jobs&sheet=stories&sheet=toolkit');
     const json = await resp.json();
     const lookup = {};
     const sheets = Object.keys(json).filter((e) => !e.startsWith(':'));


### PR DESCRIPTION
the introduction of the sitemap sheet created a side effect that changed the structure of the `lookupPages()` function slightly, which revealed an "undefined" in the carousel...

https://fix-lookup-pages--design-website--adobe.hlx.page/
vs.
https://main--design-website--adobe.hlx.page/
