### PR TITLE
fix: Story feed block listing subsection pages

### DIFF
--- a/blocks/story-feed/story-feed.js
+++ b/blocks/story-feed/story-feed.js
@@ -60,7 +60,9 @@ export default async function decorate(block) {
     pathnames.includes(e.path) &&
     /* 2) Make sure it’s not the root */
     e.path !== '/stories/' &&
-    /* 3) If not the root then check if it has the tag */
+    /* 3) Make sure it's not the tag path */
+    e.tag !== '' && 
+    /* 4) If not the root then check if it has the tag */
     e.path.includes((e.path !== '/stories/') ? `/${storiesTagPath}/` : '' )
   );
   /* eslint-enable */


### PR DESCRIPTION
## Description

This PR fixes a bug where `/stories/` also listed cards for story tags.

## Related Issue

[ADB-54](https://sparkbox.atlassian.net/browse/ADB-54)

## Motivation and Context

`story-feed` block should only generate cards for Stories.

## How Has This Been Tested?

Before fix (note 'Process' and 'Our People' at bottom of feed): https://main--design-website--adobe.hlx.page/stories/
After fix: https://sbx-fix-stories-listing-subsection-pages--design-website--adobe.hlx.page/stories/

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
