### PR TITLE
feat: Add cta block

### DIFF
--- a/blocks/cta/cta.css
+++ b/blocks/cta/cta.css
@@ -1,0 +1,108 @@
+.cmp-cta {
+  --cta-min-height: 60vh;
+
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  min-height: var(--cta-min-height);
+  margin: 0 auto;
+  padding: 9rem 3rem;
+  max-width: var(--layout-max-width-desktop);
+  background-color: var(--color-base-white);
+  color: var(--color-base-black);
+}
+
+/* CTA on Stories pages only as wide as article */
+.lede-container + .cmp-cta {
+  width: var(--content-width);
+}
+
+.cmp-cta__content {
+  --cta-content-font-size: var(--font-size-900);
+
+  max-width: 14ch;
+  margin-bottom: 3rem;
+  font-family: var(--font-stack-sans);
+  font-size: var(--cta-content-font-size);
+  font-weight: var(--font-weight-black);
+  text-align: center;
+  line-height: 1.15;
+}
+
+.cmp-cta__jobs {
+  margin-bottom: 3rem;
+}
+
+.cmp-cta__job {
+  max-width: 45ch;
+  margin-bottom: 20px;
+}
+
+.cmp-cta__job:last-child {
+  margin-bottom: 0;
+}
+
+.cmp-cta__job-title {
+  --cta-job-font-size: var(--font-size-500);
+
+  color: var(--color-base-black);
+  font-family: var(--font-stack-serif);
+  font-size: var(--cta-job-font-size);
+  text-decoration: none;
+}
+
+.cmp-cta__job-title:hover {
+  text-decoration: underline;
+}
+
+.cmp-cta__job-location {
+  color: var(--color-base-dark-slate);
+}
+
+.cmp-cta__btn {
+  display: inline-block;
+  border-radius: 1.5rem;
+  padding: 0.75rem 3rem;
+  background-color: #2f2f2f;
+  color: var(--light-text-color);
+  text-align: center;
+  transition: background-color 125ms ease-out;
+}
+
+.cmp-cta__btn:hover,
+.cmp-cta__btn:focus {
+  background-color: #3e3e3e;
+  text-decoration: none;
+}
+
+.cmp-cta__btn:active {
+  background-color: #5a5a5a;
+}
+
+@media (min-width: 600px) {
+  .cmp-cta__content {
+    --cta-content-font-size: var(--font-size-1075);
+  }
+
+  .cmp-cta__jobs {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    grid-auto-flow: row;
+    column-gap: 20px;
+    row-gap: 20px;
+  }
+
+  .cmp-cta__job {
+    margin-bottom: unset;
+    text-align: center;
+  }
+}
+
+@media (min-width: 1300px) {
+  .cmp-cta__content {
+    --cta-content-font-size: var(--font-size-2000);
+  }
+}

--- a/blocks/cta/cta.js
+++ b/blocks/cta/cta.js
@@ -1,0 +1,43 @@
+import { lookupPages } from '../../scripts/scripts.js';
+
+function addJobs(jobs) {
+  const makeJobs = document.createElement('div');
+  makeJobs.className = 'cmp-cta__jobs';
+
+  jobs.forEach((job) => {
+    makeJobs.innerHTML += `
+      <div class="cmp-cta__job">
+        <a class="cmp-cta__job-title" href="${job.path}">${job.title}</a>
+        <p class="cmp-cta__job-location">${job.location}</a>
+      </div>
+    `;
+  });
+
+  return makeJobs.outerHTML;
+}
+
+export default async function decorate(block) {
+  // Create new section
+  const makeCTA = document.createElement('section');
+  makeCTA.className = 'cmp-cta';
+  let ctaJobs = '';
+
+  // Check for jobs and generate HTML
+  const links = [...block.querySelectorAll('a')];
+  const pathnames = links.map((a) => new URL(a.href).pathname);
+  if (pathnames.length) {
+    const jobs = await lookupPages(pathnames);
+    ctaJobs = addJobs(jobs);
+  }
+
+  // Construct CTA
+  makeCTA.innerHTML = `
+    <h2 class="cmp-cta__content">Design your career at Adobe.</h2>
+    ${ctaJobs}
+    <a class="cmp-cta__btn" href="/jobs">View all jobs</a>
+  `;
+
+  // Insert above footer on page and remove original block
+  document.querySelector('main').appendChild(makeCTA);
+  block.remove();
+}

--- a/blocks/cta/cta.js
+++ b/blocks/cta/cta.js
@@ -22,6 +22,11 @@ export default async function decorate(block) {
   makeCTA.className = 'cmp-cta';
   let ctaJobs = '';
 
+  // Capture header and button copy
+  const headerCopy = block.querySelector('.cta > div:nth-child(1) > div + div').innerText;
+  const buttonCopy = block.querySelector('.cta > div:nth-child(2) > div + div').innerText;
+  const buttonPath = block.querySelector('.cta > div:nth-child(3) > div + div').innerText;
+
   // Check for jobs and generate HTML
   const links = [...block.querySelectorAll('a')];
   const pathnames = links.map((a) => new URL(a.href).pathname);
@@ -32,9 +37,9 @@ export default async function decorate(block) {
 
   // Construct CTA
   makeCTA.innerHTML = `
-    <h2 class="cmp-cta__content">Design your career at Adobe.</h2>
+    <h2 class="cmp-cta__content">${headerCopy}</h2>
     ${ctaJobs}
-    <a class="cmp-cta__btn" href="/jobs">View all jobs</a>
+    <a class="cmp-cta__btn" href=${buttonPath}>${buttonCopy}</a>
   `;
 
   // Insert above footer on page and remove original block


### PR DESCRIPTION
## Description

This PR creates new block which will replace the current Join Us section the homepage, which includes the `jobs` and `stats` block. The block is called `cta` and accepts an optional field of links to job postings.

## Related Issue

[ADB-48](https://sparkbox.atlassian.net/browse/ADB-48)

## Motivation and Context

The need to have a unified CTA that can be used throughout pages on the website. Used on the homepage, the CTA will span the width of the window. Used on a Stories page, the CTA will span the width of content.

## How Has This Been Tested?

CTA on homepage: https://sbx-jobs-block-adjustment--design-website--adobe.hlx.page/drafts/dev/cta-homepage-draft
CTA on Stories page: https://sbx-jobs-block-adjustment--design-website--adobe.hlx.page/drafts/dev/cta-stories-draft

## Screenshots (if appropriate):

Homepage:
<img width="1512" alt="Screen Shot 2022-08-24 at 10 58 08 AM" src="https://user-images.githubusercontent.com/53844657/186490709-21d6c432-52f8-464a-8a83-3d0e1b68240e.png">

Stories page:
<img width="1512" alt="Screen Shot 2022-08-24 at 10 58 22 AM" src="https://user-images.githubusercontent.com/53844657/186490741-6166aee0-17cf-4486-964e-417cbc1bf6d2.png">

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
