### PR TITLE
fix: Jobs 404 message not rendering on Safari

### DIFF
--- a/blocks/opportunities/opportunities.js
+++ b/blocks/opportunities/opportunities.js
@@ -87,18 +87,20 @@ export default async function decorate(block) {
     }
   });
 
-  if (document.body.classList.contains('active-message')) {
-    if ('IntersectionObserver' in window) {
-      const observer = new IntersectionObserver(
-        (entries) => {
-          entries.forEach((entry) => {
-            if (!entry.isIntersecting) {
-              document.body.classList.remove('active-message');
-            }
-          });
-        },
-      );
-      observer.observe(introContainer);
+  setTimeout(() => {
+    if (document.body.classList.contains('active-message')) {
+      if ('IntersectionObserver' in window) {
+        const observer = new IntersectionObserver(
+          (entries) => {
+            entries.forEach((entry) => {
+              if (!entry.isIntersecting) {
+                document.body.classList.remove('active-message');
+              }
+            });
+          },
+        );
+        observer.observe(introContainer);
+      }
     }
-  }
+  }, 375);
 }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -792,7 +792,7 @@ if (getMetadata('theme') === 'job-post') {
 
 async function jobNotFound() {
   document.body.classList.add('active-message');
-  const main = document.querySelector('main > *:first-child');
+  const container = document.querySelector('.cmp-jobs-list__intro');
   const message = document.createElement('div');
   const fullMessageText = getMetadata('job-404-message');
   const messageText = fullMessageText.split(' ').slice(0, -2).join(' ');
@@ -815,11 +815,13 @@ async function jobNotFound() {
       </div>
     </div>
   `;
-  main.parentNode.insertBefore(message, main);
+  container.prepend(message);
 }
 
 if (window.location.pathname.includes('/jobs/') && window.location.search === '?job=404') {
-  jobNotFound();
+  setTimeout(() => {
+    jobNotFound();
+  }, 325);
 }
 
 export function setTargetOnExternalLinks() {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -632,6 +632,17 @@ body.job-posts {
   }
 }
 
+/* stylelint-disable-next-line at-rule-no-vendor-prefix */
+@-webkit-keyframes cmp-jobs-message {
+  0% {
+    opacity: 0;
+  }
+
+  100% {
+    opacity: 1;
+  }
+}
+
 .jobs.active-message header {
   background-color: var(--color-base-white);
 }


### PR DESCRIPTION
## Description

This PR fixes the issue of the 404 message on the jobs page inconsistently rendering on Safari.

## Related Issue
[ADB-59](https://sparkbox.atlassian.net/browse/ADB-59)

## How Has This Been Tested?

Tested in the preview page in Safari 15: https://sbx-fix-jobs-404-safari--design-website--adobe.hlx.page/jobs/?job=404

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
