### PR TITLE
feat: Create Profiles block

### DIFF
--- a/blocks/profiles/profiles.css
+++ b/blocks/profiles/profiles.css
@@ -1,0 +1,99 @@
+.cmp-profiles {
+  --body-copy-font-size: var(--font-size-100);
+
+  font-size: var(--body-copy-font-size);
+}
+
+.cmp-profiles .cmp-profiles__header {
+  --body-copy-h3-font-size: var(--font-size-300);
+
+  font-size: var(--body-copy-h3-font-size);
+  font-weight: var(--font-weight-bold);
+}
+
+.cmp-profiles .cmp-profiles__quote {
+  margin-bottom: 3rem;
+}
+
+.cmp-profiles .cmp-profiles__quote p {
+  --body-copy-quotation-font-size: var(--font-size-200);
+
+  margin: 0;
+  font-family: var(--font-stack-serif);
+  font-size: var(--body-copy-quotation-font-size);
+  font-weight: var(--font-weight-normal);
+  line-height: 1.4;
+}
+
+.cmp-profiles__row {
+  display: flex;
+  flex-direction: column;
+}
+
+.cmp-profiles__row .cmp-profiles__column p {
+  line-height: 1.25;
+  margin-bottom: 0.75rem;
+}
+
+.cmp-profiles__row .cmp-profiles__column figure {
+  margin-bottom: 0.75rem;
+}
+
+.cmp-profiles__row .cmp-profiles__column.cmp-profiles__column--copy {
+  order: 2;
+}
+
+.cmp-profiles__row .cmp-profiles__column.cmp-profiles__column--image {
+  order: 1;
+}
+
+@media (min-width: 600px) {
+  .cmp-profiles__row {
+    flex-direction: row;
+    gap: 12px;
+    margin-bottom: 1rem;
+  }
+
+  .cmp-profiles__column--align-right {
+    text-align: right;
+  }
+
+  .cmp-profiles__row .cmp-profiles__column figure {
+    margin-bottom: unset;
+  }
+
+  .cmp-profiles__row .cmp-profiles__column.cmp-profiles__column--copy {
+    order: unset;
+    flex: 0 1 50%;
+  }
+
+  .cmp-profiles__row .cmp-profiles__column.cmp-profiles__column--image {
+    order: unset;
+    flex: 0 1 50%;
+  }
+}
+
+@media (min-width: 900px) {
+  .cmp-profiles {
+    --body-copy-font-size: var(--font-size-400);
+  }
+
+  .cmp-profiles .cmp-profiles__header {
+    --body-copy-h3-font-size: var(--font-size-600);
+  }
+  
+  .cmp-profiles .cmp-profiles__quote p {
+    --body-copy-quotation-font-size: var(--font-size-500);
+  }
+}
+
+@media (min-width: 1300px) {
+  .cmp-profiles__row .cmp-profiles__column.cmp-profiles__column--copy {
+    flex: 0 1 66%;
+  }
+
+  .cmp-profiles__row .cmp-profiles__column.cmp-profiles__column--image {
+    min-height: 100%;
+    flex: 1 0 34%;
+  }
+}

--- a/blocks/profiles/profiles.js
+++ b/blocks/profiles/profiles.js
@@ -1,0 +1,89 @@
+function generateHeader(headerElement) {
+  const makeHeader = document.createElement('h3');
+  makeHeader.classList.add('cmp-profiles__header');
+
+  makeHeader.textContent = headerElement.textContent;
+  return makeHeader;
+}
+
+function generateQuote(quoteElement) {
+  const makeQuote = document.createElement('blockquote');
+  const makeParagraph = document.createElement('p');
+  makeQuote.classList.add('cmp-profiles__quote');
+
+  makeParagraph.textContent = quoteElement.textContent;
+  makeQuote.append(makeParagraph);
+  return makeQuote;
+}
+
+function generateContent(textElement) {
+  const sectionText = textElement.innerHTML.split('<br>');
+  const sectionParagraphs = [...sectionText].map((section) => `<p>${section}</p>`);
+
+  const template = document.createElement('template');
+  template.innerHTML = sectionParagraphs.join('');
+
+  const result = template.content;
+  return result;
+}
+
+function generateFigure(pictureElement) {
+  const makeFigure = document.createElement('figure');
+  makeFigure.append(pictureElement);
+  return makeFigure;
+}
+
+export default async function decorate(block) {
+  // Create container
+  const makeImageWithCopy = document.createElement('div');
+  makeImageWithCopy.classList.add('cmp-profiles');
+
+  const rows = [...block.querySelectorAll(':scope > div')]
+    .map((row) => row.querySelectorAll(':scope > div'));
+
+  // Create rows
+  rows.forEach((row) => {
+    const makeRow = document.createElement('div');
+    makeRow.classList.add('cmp-profiles__row');
+    let makeQuote;
+
+    // Create columns
+    row.forEach((column) => {
+      const makeColumn = document.createElement('div');
+      makeColumn.classList.add('cmp-profiles__column');
+
+      // Columns without <picture> as the first child is copy
+      const isText = column.querySelector(':scope > :first-child').nodeName !== 'PICTURE';
+      if (isText) {
+        makeColumn.classList.add('cmp-profiles__column--copy');
+        // Create header and quote paragraph
+        const introElements = column.querySelectorAll('h3');
+        const makeHeader = generateHeader(introElements[0]);
+        makeQuote = generateQuote(introElements[1]);
+        makeColumn.append(makeHeader);
+
+        const textElement = column.querySelector(':scope > p');
+        const makeText = generateContent(textElement);
+        makeColumn.append(makeText);
+      } else {
+        makeColumn.classList.add('cmp-profiles__column--image');
+        const makeFigure = generateFigure(column.querySelector(':scope > :first-child'));
+        makeColumn.append(makeFigure);
+      }
+
+      makeRow.append(makeColumn);
+    });
+
+    makeImageWithCopy.append(makeRow);
+    makeImageWithCopy.append(makeQuote);
+  });
+
+  // If first column is text content, right-align text
+  const leadingElement = makeImageWithCopy.querySelectorAll(':scope > div > :first-child > :first-child');
+  leadingElement.forEach((element) => {
+    if (element.nodeName !== 'FIGURE') element.parentNode.classList.add('cmp-profiles__column--align-right');
+  });
+
+  block.parentNode.insertBefore(makeImageWithCopy, block);
+  block.remove();
+}


### PR DESCRIPTION
## Description

This PR creates a new block called `profiles`, which displays a header followed by a quote, followed by an image and other text content. The block can handle one to multiple profiles, and the image and text content can be displayed in variable order.

## Related Issue

[ADB-46](https://sparkbox.atlassian.net/browse/ADB-46)

## Motivation and Context

The main use-case for this block will be for an upcoming page.

## How Has This Been Tested?

Tested on preview site: https://sbx-image-with-copy--design-website--adobe.hlx.page/drafts/dev/profiles-draft

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
