### PR TITLE
feat: Create Image With Text block

### DIFF
--- a/blocks/image-with-text/image-with-text.css
+++ b/blocks/image-with-text/image-with-text.css
@@ -1,0 +1,73 @@
+.cmp-image-with-text {
+  --body-copy-font-size: var(--font-size-100);
+
+  font-size: var(--body-copy-font-size);
+}
+
+.cmp-image-with-text__row {
+  display: flex;
+  flex-direction: column;
+  margin: 5.25rem 0;
+}
+
+h3 + .cmp-image-with-text .cmp-image-with-text__row {
+  margin: 2.75rem 0;
+}
+
+.cmp-image-with-text__row .cmp-image-with-text__column p {
+  line-height: 1.75;
+  margin-bottom: 0;
+}
+
+.cmp-image-with-text__row .cmp-image-with-text__column figure {
+  margin-bottom: 1rem;
+}
+
+.cmp-image-with-text__row .cmp-image-with-text__column.cmp-image-with-text__column--copy {
+  order: 2;
+}
+
+.cmp-image-with-text__row .cmp-image-with-text__column.cmp-image-with-text__column--image {
+  order: 1;
+}
+
+@media (min-width: 600px) {
+  .cmp-image-with-text__row {
+    flex-direction: row;
+    gap: 24px;
+  }
+
+  .cmp-image-with-text__row .cmp-image-with-text__column figure {
+    margin-bottom: unset;
+  }
+
+  .cmp-image-with-text__row .cmp-image-with-text__column.cmp-image-with-text__column--copy {
+    order: unset;
+    flex: 0 1 50%;
+  }
+
+  .cmp-image-with-text__row .cmp-image-with-text__column.cmp-image-with-text__column--image {
+    order: unset;
+    flex: 0 1 50%;
+  }
+}
+
+@media (min-width: 900px) {
+  .cmp-image-with-text {
+    --body-copy-font-size: var(--font-size-400);
+  }
+}
+
+@media (min-width: 1300px) {
+  .cmp-image-with-text__row {
+    margin: 2.125rem 0 3.625rem;
+  }
+
+  .cmp-image-with-text__row .cmp-image-with-text__column.cmp-image-with-text__column--copy {
+    flex: 0 1 66%;
+  }
+
+  .cmp-image-with-text__row .cmp-image-with-text__column.cmp-image-with-text__column--image {
+    flex: 0 1 33%;
+  }
+}

--- a/blocks/image-with-text/image-with-text.js
+++ b/blocks/image-with-text/image-with-text.js
@@ -1,0 +1,55 @@
+function generateFigure(pictureElement) {
+  const makeFigure = document.createElement('figure');
+  makeFigure.append(pictureElement);
+  return makeFigure;
+}
+
+function generateParagraph(text) {
+  const makeParagraph = document.createElement('p');
+  makeParagraph.innerHTML = text.innerHTML;
+  return makeParagraph;
+}
+
+export default async function decorate(block) {
+  // Create container
+  const makeBlock = document.createElement('div');
+  makeBlock.classList.add('cmp-image-with-text');
+
+  const rows = [...block.querySelectorAll(':scope > div')]
+    .map((row) => row.querySelectorAll(':scope > div'));
+
+  // Create rows
+  rows.forEach((row) => {
+    const makeRow = document.createElement('div');
+    makeRow.classList.add('cmp-image-with-text__row');
+
+    // Create columns
+    row.forEach((column) => {
+      const makeColumn = document.createElement('div');
+      makeColumn.classList.add('cmp-image-with-text__column');
+
+      // Columns without <picture> as the first child is text
+      const isPicture = column.querySelector(':scope > *').nodeName === 'PICTURE';
+      if (isPicture) {
+        makeColumn.classList.add('cmp-image-with-text__column--image');
+
+        const makeFigure = generateFigure(column.querySelector(':scope > :first-child'));
+        makeColumn.append(makeFigure);
+      } else {
+        makeColumn.classList.add('cmp-image-with-text__column--copy');
+
+        const makeParagraph = generateParagraph(column);
+        makeColumn.append(makeParagraph);
+      }
+
+      // Add column to row
+      makeRow.append(makeColumn);
+    });
+
+    // Add row to block
+    makeBlock.append(makeRow);
+  });
+
+  block.parentNode.insertBefore(makeBlock, block);
+  block.remove();
+}


### PR DESCRIPTION
## Description

This PR creates a new block called `image with text`, which displays a two-column layout with image on one side and text on the other. Image and text content can be displayed in either order.

## Related Issue

[ADB-46](https://sparkbox.atlassian.net/browse/ADB-46)

## Motivation and Context

The main use-case for this block will be for an upcoming page.

## How Has This Been Tested?

Tested on preview site: https://sbx-image-with-text--design-website--adobe.hlx.page/drafts/dev/profiles-draft

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
