### PR TITLE
feat: Add Simplecast handling to embed block

### DIFF
--- a/blocks/embed/embed.js
+++ b/blocks/embed/embed.js
@@ -31,6 +31,19 @@ const EMBEDS_CONFIG = {
       </blockquote>
     `,
   },
+  simplecast: {
+    type: 'simplecast',
+    createEmbed: (url) => `
+      <iframe
+        height="200px"
+        width="100%"
+        frameborder="no"
+        scrolling="no"
+        seamless
+        src="${url}"
+      ></iframe>
+    `,
+  },
 };
 
 const setConfig = (embedCode) => {
@@ -39,6 +52,8 @@ const setConfig = (embedCode) => {
       return EMBEDS_CONFIG.instagram;
     case (embedCode.includes('twitter')):
       return EMBEDS_CONFIG.twitter;
+    case (embedCode.includes('simplecast')):
+      return EMBEDS_CONFIG.simplecast;
     default:
       return null;
   }
@@ -60,7 +75,9 @@ export default async function decorate(block) {
   block.remove();
 
   // Import script into head
-  const createScript = document.createElement('script');
-  createScript.setAttribute('src', config.url);
-  document.querySelector('head').append(createScript);
+  if (config.url) {
+    const createScript = document.createElement('script');
+    createScript.setAttribute('src', config.url);
+    document.querySelector('head').append(createScript);
+  }
 }


### PR DESCRIPTION
## Description

This PR adds the ability for the `embed` block to handle embedding the Simplecast player.

## Related Issue

[ADB-65](https://sparkbox.atlassian.net/browse/ADB-65)

## Motivation and Context

Need functionality for a future Story.

## How Has This Been Tested?

Tested in preview site: https://sbx--simplecast-embed--design-website--adobe.hlx.page/drafts/dev/embed-draft

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
