### PR TITLE
fix: add margin to `collaborators`

### DIFF
--- a/blocks/collaborators/collaborators.css
+++ b/blocks/collaborators/collaborators.css
@@ -1,11 +1,16 @@
 .collaborators {
   background-color: var(--color-base-light-rose);
   grid-column: 1 / -1;
+  margin: 12px 0;
   padding: 5.25rem var(--page-inline-padding) 0;
 }
 
 .design-circle .collaborators {
   margin-bottom: 12px;
+}
+
+.inclusive-design .collaborators {
+  margin: 0;
 }
 
 .collaborators:last-of-type {


### PR DESCRIPTION
## Description

This PR affects the `collaborators` block, and adds a margin when it is used on the site other than the Inclusive Design page.

## Related Issue

[ADB-69](https://sparkbox.atlassian.net/browse/ADB-69)

## How Has This Been Tested?

Preview Inclusive Design page: https://sbx-collaborators-styling--design-website--adobe.hlx.page/toolkit/inclusive-design/

Preview Product Equity page: https://sbx-collaborators-styling--design-website--adobe.hlx.page/toolkit/product-equity-at-adobe

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
