### PR TITLE
fix: Revert JSON file to only use index version

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -533,12 +533,7 @@ loadPage(document);
 
 export async function lookupPages(pathnames) {
   if (!window.pageIndex) {
-    const file = window.location.host === (
-      'adobe.design'
-      || 'main--design-website--adobe.hlx.page'
-      || 'main--design-website--adobe.hlx.live'
-    ) ? '/query-index.json?sheet=jobs&sheet=stories&sheet=toolkit'
-      : '/query-dev.json?sheet=jobs&sheet=stories&sheet=toolkit';
+    const file = '/query-index.json?sheet=jobs&sheet=stories&sheet=toolkit';
     const resp = await fetch(file);
     const json = await resp.json();
     const lookup = {};


### PR DESCRIPTION
https://update-lookup-pages-function--design-website--adobe.hlx.page/drafts/product-equity-at-adobe

This reverts the `lookupPages` function to only use the `query-index.json` file and not the `query-dev.json` file which was set up to test on branches.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
