### PR TITLE
chore: remove special case to suppress authorbox

### DIFF
--- a/blocks/lede/lede.js
+++ b/blocks/lede/lede.js
@@ -97,12 +97,10 @@ export default async function decorate(block) {
     `;
   });
 
-  // only create & decorate "author details" block if the author IS NOT 'adobe design'
+  // only create & decorate "author details" block if there is an author
   const authorDetailsName = getMetadata('author');
   if (
     authorDetailsName !== null
-    && authorDetailsName.toLowerCase() !== 'adobe design team'
-    && authorDetailsName.toLowerCase() !== 'adobe design'
   ) {
     const articleDetailsBlock = document.createElement('div');
     articleDetailsBlock.classList.add('cmp-author-details');

--- a/scripts/get-author-titles.js
+++ b/scripts/get-author-titles.js
@@ -1,12 +1,15 @@
 export default async function getAuthorTitles(row) {
   if (row.author.indexOf(',') !== -1) {
     const authorNames = row.author.split(', ');
+    const file = '/query-index.json?sheet=jobs&sheet=stories&sheet=toolkit&sheet=sitemap';
+    /*
     const file = window.location.host === (
       'adobe.design'
       || 'main--design-website--adobe.hlx.page'
       || 'main--design-website--adobe.hlx.live'
     ) ? '/query-index.json?sheet=jobs&sheet=stories&sheet=toolkit&sheet=sitemap'
       : '/query-dev.json?sheet=jobs&sheet=stories&sheet=toolkit&sheet=sitemap';
+      */
     const resp = await fetch(file);
     const json = await resp.json();
     const authorData = json.sitemap.data.filter((e) => e.path.startsWith('/authors/'));


### PR DESCRIPTION
https://authorbox-on--design-website--adobe.aem.page/stories/community/adobe-design-talks-why-generative-ai-needs-design-leadership

vs. 

https://main--design-website--adobe.aem.page/stories/community/adobe-design-talks-why-generative-ai-needs-design-leadership
